### PR TITLE
deprecate gha artifact name

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,25 +5,21 @@ This GitHub Action sets up the job workspace by checking the job type, optionall
 _*NOTE: This workflow is opinionated and meets the needs of its author. It is provided publicly as a reference for others to use and modify as needed.*_
 
 The `gha-setup-workspace` action performs the following tasks:
-* Sets additional GitHub Actions environment variables.
-* Checks the job of checkout (source or artifact)
-* Checks out the source code if checkout_artifact is `false`.
-* Determines the artifact name based on the provided override or generates a default name.
-* Downloads the artifact if checkout_artifact is `true`
-* .
+- Sets additional GitHub Actions environment variables.
+- Checks the job of checkout (source or artifact)
+- Checks out the source code if checkout_artifact is `false`.
+- Downloads the artifact if checkout_artifact is `true`
 
 ## Usage
 See below for inputs, outputs, and examples.
 
 ### Inputs
 
-- `artifact_name_override` (optional): Override the name of the artifact to use. Default is an empty string which determines the artifact name automatically. 
 - `checkout_artifact` (optional): Whether to checkout artifact instead of source. Value must be `true` or `false`.
 - `checkout_fetch_depth` (optional): The number of commits to fetch. Change to `0` if performing a merge.
 
 ## Outputs
 
-- `artifact-name`: The name of the artifact downloaded.
 - `is-artifact`: Checkout type is artifact.
 - `is-source`: Checkout type is source.
 
@@ -52,42 +48,6 @@ jobs:
         uses: ServerlessOpsIO/gha-setup-workspace@v1
         with:
           checkout_artifact: true
-```
-
-### Configuration
-See below for extended information on certain configuration.
-
-#### Artifact naming
-
-Both [ServerlessOpsIO/gha-setup-workspace](https://github.com/ServerlessOpsIO/gha-setup-workspace) and [ServerlessOpsIO/gha-store-artifacts](https://github.com/ServerlessOpsIO/gha-store-artifacts) use the same [utility action](https://github.com/ServerlessOpsIO/gha-artifact-name) to set an artifact name if `artifact_name_override` is not set. If your workflow sets _artifact_name_override_ for `ServerlessOpsIO/gha-setup-workspace` be sure to use that actions _artifact_name_ output to set _artifact_name_override_ for `ServerlessOpsIO/gha-store-artifacts`.
-
-See the example below:
-
-```yaml
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Setup job workspace
-        uses: ServerlessOpsIO/gha-setup-workspace@v1
-      - name: Store Artifacts
-        uses: ServerlessOpsIO/gha-store-artifacts@v1
-        with:
-          artifact_name_override: 'MyArtifactName'
-    outputs:
-      artifact-name: ${{ steps.setup-workspace.outputs.artifact-name }}
-
-  deploy:
-    runs-on: ubuntu-latest
-    needs:
-      - build
-    steps:
-      - name: Setup job workspace
-        uses: ServerlessOpsIO/gha-setup-workspace@v1
-        with:
-          checkout_artifact: true
-          artifact_name_override: ${{ needs.build.outputs.artifact-name }}
-
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -6,18 +6,33 @@ _*NOTE: This workflow is opinionated and meets the needs of its author. It is pr
 
 The `gha-setup-workspace` action performs the following tasks:
 - Sets additional GitHub Actions environment variables.
-- Checks the job of checkout (source or artifact)
+- Checks the checkout type (source or artifact).
 - Checks out the source code if checkout_artifact is `false`.
-- Downloads the artifact if checkout_artifact is `true`
+- Downloads the artifact if checkout_artifact is `true`.
 
 ## Usage
 See below for inputs, outputs, and examples.
 
 ### Inputs
 
-- `checkout_artifact` (optional): Whether to checkout artifact instead of source. Value must be `true` or `false`.
+- `checkout_artifact` (optional): Whether to checkout artifact instead of source. Value must be `true` or `false`. When set to `true`, this action downloads artifacts using the default behavior of `actions/download-artifact`.
 - `checkout_fetch_depth` (optional): The number of commits to fetch. Change to `0` if performing a merge.
 
+### Artifact selection behavior
+
+When `checkout_artifact` is `true`, this action does not specify an artifact name when downloading artifacts.
+As a result, it relies on the default behavior of `actions/download-artifact`, which downloads all available artifacts for the workflow run when no name is provided.
+
+If your workflow expects exactly one artifact to be present in the workspace, configure upstream jobs to upload only one artifact for that run.
+If multiple artifacts are uploaded, all of them may be downloaded into the workspace.
+
+### Artifact selection behavior
+
+When `checkout_artifact` is `true`, this action does not specify an artifact name when downloading artifacts.
+As a result, it relies on the default behavior of `actions/download-artifact`, which downloads all available artifacts for the workflow run when no name is provided.
+
+If your workflow expects exactly one artifact to be present in the workspace, configure upstream jobs to upload only one artifact for that run.
+If multiple artifacts are uploaded, all of them may be downloaded into the workspace.
 ## Outputs
 
 - `is-artifact`: Checkout type is artifact.

--- a/action.yaml
+++ b/action.yaml
@@ -2,9 +2,6 @@ name: 'setup-workspace'
 description: 'Setup job workspace'
 
 inputs:
-  artifact_name_override:
-    description: Override name of artifact to use
-    required: false
   checkout_fetch_depth:
     description: Depth to fetch repository
     required: false
@@ -45,23 +42,12 @@ runs:
       with:
         fetch-depth: ${{ inputs.checkout_fetch_depth }}
 
-    - name: Set artifact name
-      id: set-artifact-name
-      uses: ServerlessOpsIO/gha-artifact-name@v1
-      with:
-        artifact_name_override: ${{ inputs.artifact_name_override }}
-
     - name: Download artifact
       id: download-artifact
       if: inputs.checkout_artifact == 'true'
       uses: actions/download-artifact@v5
-      with:
-        name: ${{ steps.set-artifact-name.outputs.artifact-name }}
 
 outputs:
-    artifact-name:
-        description: Name of artifact downloaded
-        value: ${{ steps.set-artifact-name.outputs.artifact-name }}
     is-artifact:
         description: Checkout type is artifact
         value: ${{ steps.checkout-type.outputs.is-artifact }}


### PR DESCRIPTION
When I wrote this initially I was under the belief that runs would overwrite artifacts from previous runs if the name wasn't unique but upon looking at GitHub recently that's not the case. Removing this because we don't need it